### PR TITLE
Added stub for DDTrace\\Bridge\\dd_tracing_enabled.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,6 @@
   "autoload":  {
     "files": [
       "stubs/functions.php"
-    ],
-    "psr-4": {
-      "DDTrace\\": "stubs/"
-    }
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,13 @@
   },
   "require-dev": {
     "datadog/dd-trace": "^0.59.0"
+  },
+  "autoload":  {
+    "files": [
+      "stubs/functions.php"
+    ],
+    "psr-4": {
+      "DDTrace\\": "stubs/"
+    }
   }
 }

--- a/stubs/functions.php
+++ b/stubs/functions.php
@@ -44,3 +44,13 @@ namespace DDTrace {
         }
     }
 }
+
+namespace DDTrace\Bridge {
+    if (!function_exists('DDTrace\\Bridge\\dd_tracing_enabled')) {
+        function dd_tracing_enabled(): bool
+        {
+            return false;
+        }
+    }
+}
+


### PR DESCRIPTION
This function "does not exist" when the extension is enabled, but DD_TRACE_ENABLED=false.

This change also introduces autoloading.