### PR TITLE
Corrects signature of DDTrace\trace_method stub and adds DDTrace\trace_function

### DIFF
--- a/stubs/functions.php
+++ b/stubs/functions.php
@@ -30,9 +30,18 @@ namespace DDTrace {
 
     if (!function_exists('DDTrace\trace_method')) {
         /**
-         * @phpstan-param \Closure(DDTrace\SpanData, list<mixed>=, mixed|null=, \Throwable|null=): void $tracingClosure
+         * @phpstan-param \Closure|array $tracingClosure
          */
-        function trace_method(string $className, string $methodName, \Closure $tracingClosure): void
+        function trace_method(string $className, string $methodName, $tracingClosure): void
+        {
+        }
+    }
+
+    if (!function_exists('DDTrace\trace_function')) {
+        /**
+         * @phpstan-param \Closure|array $tracingClosure
+         */
+        function trace_function(string $functionName, $tracingClosure): void
         {
         }
     }


### PR DESCRIPTION
- Loosens signature of trace_method stub to be more in line with the library
- Changes the stan annotation to sufficient, yet simpler
- Introduces stub for DDTrace\trace_function

![](https://media3.giphy.com/media/xT5LMsVTNO9b1wHKDe/giphy.gif)